### PR TITLE
Encyclopedia fix for Cultures-related text

### DIFF
--- a/GAME.NFO
+++ b/GAME.NFO
@@ -166,8 +166,8 @@ became negotiators between the people and the spiritworld, the
 otherworld, The Real World.
 ***
 
-.TIETÂŽJÂŽ.
-"TietÂ„jÂ„" means literally "the one who knows the road", e.g.
+.TIETŽJŽ.
+"Tiet„j„" means literally "the one who knows the road", e.g.
 the sage, the sorcerer or the wise man.
 ***
 
@@ -180,14 +180,14 @@ for the special knowledge of a gifted person who acts as a negotiatior between h
 <br>
 Northern peoples have shamans as negotiators between the humans
 and the spiritworld. Among eastern and western peoples the
-equivalent of shaman is a tietÂ„jÂ„. But there are some differences
-in techniques used by shamans and tietÂ„jÂ„t. A shaman masters
-a special drumming technique, and a tietÂ„jÂ„ is familiar with
+equivalent of shaman is a tiet„j„. But there are some differences
+in techniques used by shamans and tiet„j„t. A shaman masters
+a special drumming technique, and a tiet„j„ is familiar with
 techniques of verbal exctacy and rune singing. The social
-role of a shaman or a tietÂ„jÂ„ is a very demanding one, for they
+role of a shaman or a tiet„j„ is a very demanding one, for they
 are responsible for the welfare of the entire community.
 The position is often handed down from an old master to an apprentice,
-but there are also some self-thaught healers who become a shaman or a tietÂ„jÂ„ when
+but there are also some self-thaught healers who become a shaman or a tiet„j„ when
 the local people regularly come to seek their servives.<br>
 <br>
  The basic relation between the humans and the spirits is that
@@ -212,7 +212,7 @@ to cause harm, such as diseases and madness. Almost
 anyone can consult his or her late relatives to ask
 help, for example. But when there are some more
 serious problems, such as restless souls of the violently
-killed people, it is the duty of the tietÂ„jÂ„ to
+killed people, it is the duty of the tiet„j„ to
 restore the normal situation.
 %POP%
 kaarme.jpg 400x300
@@ -262,17 +262,17 @@ A group of single farms is called a village. Northern tribes don't have
 proper villages at all. Kaumolaiset and Islanders also tend to live in
 rather isolated single farms. In the Driik one might find villages which
 are dense groups of four to five farms interconnected with roads. The rest
-of the cultures have somewhat looser villages.
+of the cultures have somewhat looser villages. 
 ***
 
 .EASTERN PEOPLES.
 The eastern peoples are:
-KAUMOLAISET, KIESSELÂŽISET and REEMILÂŽISET
+KAUMOLAISET, KIESSELŽISET and REEMILŽISET
 ***
 
 .WESTERN PEOPLES.
 The western peoples are:
-DRIIKILÂŽISET, SARTOLAISET, ISLANDERS and KOIVULAISET
+DRIIKILŽISET, SARTOLAISET, ISLANDERS and KOIVULAISET
 ***
 
 .KAUMOLAISET.KAUMO.
@@ -293,55 +293,55 @@ furious, putting up heavy resistance with a spear, a knife or even with
 their bare hands.<br>
 ***
 
-.KIESSELÂŽISET.KIESSE.
-KiesselÂ„iset (Those Who Live In The Kiesse) have small, loose villages,
-usually located near lakes or rivers. KiesselÂ„iset earn their daily living
+.KIESSELŽISET.KIESSE.
+Kiessel„iset (Those Who Live In The Kiesse) have small, loose villages,
+usually located near lakes or rivers. Kiessel„iset earn their daily living
 mainly by the means of fishing, hunting and slash-and-burn agriculture.
 Typically they cut down a small area of forest each year, burning the trees,
 which yields them fresh fertile land for cultivation. This kind of field
 is exhausted in five or six years. After that the area is left as a pasture
-for animals. When a kiesselÂ„is family finds that there is no more old forests
+for animals. When a kiessel„is family finds that there is no more old forests
 near their home, it is very common for them just to take down their buildings,
 to move in a new place with plenty of old forest to cut and burn.<br>
 <br>
-  The kiesselÂ„iset are peaceful people. They like to joke about everything,
-to tell stories and to avoid fighting.
+  The kiessel„iset are peaceful people. They like to joke about everything,
+to tell stories and to avoid fighting. 
 ***
 
-.DRIIKILÂŽISET.DRIIK.
-DriikilÂ„iset (Those Who Live In The Driik) live on the south-west
+.DRIIKILŽISET.DRIIK.
+Driikil„iset (Those Who Live In The Driik) live on the south-west
 coastal area. They live in villages and towns, which are usually
-protected by walls, watchtowers and fortresses. DriikilÂ„iset are
+protected by walls, watchtowers and fortresses. Driikil„iset are
 traders. They send their ships abroad, they trade with inland
 peasants and with the fishermen of the archipelago. From time to time
-DriikilÂ„iset are attacked by foreign pirates and bandits who may
+Driikil„iset are attacked by foreign pirates and bandits who may
 sometimes sail from a great distance to attack Driik coast.<br>
 <br>
-   DriikilÂ„iset can be considered to be more organized than rest of
+   Driikil„iset can be considered to be more organized than rest of
 the peoples of The UnReal World. They have differentiated
 professions - merchants, soldiers, sailors and so on. If needed,
-DriikilÂ„iset can afford crossbows, metal armours, swords, battleaxes
+Driikil„iset can afford crossbows, metal armours, swords, battleaxes
 and full-metal shields.
 ***
 
-.REEMILÂŽISET.REEMI.
-ReemilÂ„iset (Those Who Live In The Reemi) live in the
+.REEMILŽISET.REEMI.
+Reemil„iset (Those Who Live In The Reemi) live in the
 south-east part of the UnReal World. They have prosperous
 villages and they earn their daily living mainly by means
 of agriculture. Regular fishing, passive hunting and trading
 adds a steady flow of wealth.<br>
 <br>
-  ReemilÂ„iset like to build big, protected houses. They
+  Reemil„iset like to build big, protected houses. They
 have a deep respect for the spiritworld and their ancestors.
 ***
 
 .SARTOLAISET.SARTOLA.
 Sartolaiset (Those Who Live In The Sartola) have their
-home in the western coastal area of the UnReal World.
+home in the western coastal area of the UnReal World. 
 They have settled to live in small agricultural villages,
 farming for food and trapping for furs.<br>
 <br>
-   Sartolaiset trade mainly with DriikilÂ„iset, trading
+   Sartolaiset trade mainly with Driikil„iset, trading
 furs for salt, tools and luxuries. They are proud of their
 wealth, which they display by building big houses. They
 like wrestling for fun. And if the situation gets serious,
@@ -410,11 +410,11 @@ The Seal.
 
 // upd 11-Dec-2014
 .NJERPEZIT.NJERPEZ.
-Njerpezit are of eastern race. Black haired Njerpez men are considered notorious bandits.
-Njerpez men do attack other people, killing, robbing and raiding.
-Their typical melee weapons consist of spears, scimitars and roundshields.
+Njerpezit are of eastern race. Black haired Njerpez men are considered notorious bandits. 
+Njerpez men do attack other people, killing, robbing and raiding. 
+Their typical melee weapons consist of spears, scimitars and roundshields. 
 Chieftains might have helms and lamellar armours, and more rarely mail gear.
-Njerpez are interested in furs, those of squirrels, bears, wolves, beavers and lynxes.
+Njerpez are interested in furs, those of squirrels, bears, wolves, beavers and lynxes. 
 Animal fur is of the very best quality in The Kaumo, and the merchants of the southern
 domains are willing to pay plenty for the finest northern furs. Njerpezit strive for
 conquering the hunting-grounds of Kaumolaiset, and this is what they have been doing for decades.
@@ -436,20 +436,20 @@ See language inflexions table for further information.
  REGION     AN INHABITANT   MANY INHABITANTS   ADJECTIVE <br>
 ----------------------------------------------------------<br>
  Kaumo      a kaumolainen   kaumolaiset        kaumolais<br>
- Kiesse     a kiesselÂ„inen  kiesselÂ„iset       kiesselÂ„is<br>
- Driik      a driikilÂ„inen  driikilÂ„iset       driikilÂ„is<br>
- Reemi      a reemilÂ„inen   reemilÂ„iset        reemilÂ„is<br>
+ Kiesse     a kiessel„inen  kiessel„iset       kiessel„is<br>
+ Driik      a driikil„inen  driikil„iset       driikil„is<br>
+ Reemi      a reemil„inen   reemil„iset        reemil„is<br>
  Sartola    a sartolainen   sartolaiset        sartolais<br>
  Koivula    a koivulainen   koivulaiset        koivulais<br>
 <br>
 Examples:<br>
 <br>
  He is a kaumolainen = He comes from Kaumo<br>
- He is a driikilÂ„inen = He comes from Driik<br>
- They are drikkilÂ„iset = They come from Driik<br>
+ He is a driikil„inen = He comes from Driik<br>
+ They are drikkil„iset = They come from Driik<br>
  This is an kaumolais spear = This spear is made by kaumolaiset<br>
- These are kiesselÂ„is punts = These punts are made in Kiesse<br>
- This is a driikilÂ„is town = DriikilÂ„iset live in this town<br>
+ These are kiessel„is punts = These punts are made in Kiesse<br>
+ This is a driikil„is town = Driikil„iset live in this town<br>
 ***
 
 .TERRAIN.
@@ -457,7 +457,7 @@ The main terrain types are forests, mires and lakes. Terrain type
 affects to what kind of trees, plants, berries, mushrooms can be found at the
 area and so on.<br>
 <br>
-This topic is under construction.
+This topic is under construction. 
 ***
 
 .WEATHER.
@@ -479,7 +479,7 @@ come and go without any regular patterns.
   In the autumn migrating birds leave, hibernating animals
 seek and eat a lot of food. Usually it rains a lot in the autumn.
 
-This topic is under construction.
+This topic is under construction. 
 ***
 
 .PLANTS.


### PR DESCRIPTION
There are some special characters (I suppose that we're talking about Finnish chars) that have been messed up during conversion.
This commit tries to fix the Encyclopedia related to Cultures, because otherwise during Character creation you cannot browse Cultural informations.